### PR TITLE
Set title and description in DAO detail page by fetching OGP info from each link

### DIFF
--- a/src/components/ShopCard/ShopDetail.tsx
+++ b/src/components/ShopCard/ShopDetail.tsx
@@ -13,12 +13,14 @@ import {
   Card,
   CardHeader,
 } from "@chakra-ui/react";
+import { OgObject } from "open-graph-scraper/dist/lib/types";
 import { FiExternalLink } from "react-icons/fi";
 
 interface ShopDetailCardProps {
   storeUrl: string;
+  og: OgObject;
 }
-export const ShopDetailCard: React.FC<ShopDetailCardProps> = ({ storeUrl }) => (
+export const ShopDetailCard: React.FC<ShopDetailCardProps> = ({ storeUrl, og }) => (
   <Card
     width={{ base: "full", md: "auto" }}
     bg="bg-surface"
@@ -34,28 +36,28 @@ export const ShopDetailCard: React.FC<ShopDetailCardProps> = ({ storeUrl }) => (
         <Image
           objectFit="cover"
           maxW={{ base: "100%", sm: "600px" }}
-          src="https://htmlburger.com/blog/wp-content/uploads/2022/07/Shopify-Website-Examples.jpg"
-          alt="Shop OGP"
+          src={(typeof og.ogImage === 'string' ? og.ogImage : Array.isArray(og.ogImage) ? og.ogImage.at(0)?.url : og.ogImage?.url) ?? 'https://htmlburger.com/blog/wp-content/uploads/2022/07/Shopify-Website-Examples.jpg'}
+          alt={og.ogTitle}
         />
       </Box>
 
       <VStack align="start" spacing="3">
         <CardBody>
           <Heading size="md" my={"2"}>
-            Sample OGP Title Client Report
+            {og.ogTitle}
           </Heading>
 
           <Heading size="xs" textTransform="uppercase">
             OGP data ref
           </Heading>
           <Text py="2">
-            Sample OGP Description that summarizes the content of the website.
+            {og.ogDescription}
           </Text>
           <Heading size="xs" textTransform="uppercase">
             Overview
           </Heading>
           <Text py="2">
-            Sample OGP Description that summarizes the content of the website.
+            {og.ogDescription}
           </Text>
         </CardBody>
       </VStack>

--- a/src/pages/dao/[id].tsx
+++ b/src/pages/dao/[id].tsx
@@ -31,6 +31,8 @@ import {
 } from "@chakra-ui/react";
 import { FiExternalLink, FiFileText, FiSettings } from "react-icons/fi";
 import router, { useRouter } from "next/router";
+import openGraphScraper from "open-graph-scraper";
+import { OgObject } from "open-graph-scraper/dist/lib/types";
 
 import { DAOData, DAODataList } from "../../mocks/DAOs";
 
@@ -40,8 +42,10 @@ import { ShopDetailCard } from "@/components/ShopCard";
 import { DAODetailInfo } from "@/components/DAOCard/DAODetailInfo";
 
 import { ProposalList } from "@/components/ProposalCard/ProposalList";
+import { GetStaticPaths, GetStaticProps } from "next";
+import { DAODataType } from "@/types/DAOdata";
 
-export default function Dao() {
+export default function Dao(daoData: DAODataType & { og: OgObject }) {
   const router = useRouter();
   const { id } = router.query;
 
@@ -49,8 +53,8 @@ export default function Dao() {
     return null;
   }
 
-  const { name, storeUrl, symbol, stats, proposals, contractParameters } =
-    DAODataList[Number(id)];
+  const { name, storeUrl, symbol, stats, proposals, contractParameters, og } =
+    daoData;
 
   return (
     <Box
@@ -64,9 +68,30 @@ export default function Dao() {
     >
       <DAODetailInfo daoData={DAOData} />
 
-      <ShopDetailCard storeUrl={storeUrl} />
+      <ShopDetailCard storeUrl={storeUrl} og={og} />
 
       <ProposalList proposals={proposals} />
     </Box>
   );
+}
+
+export const getStaticProps: GetStaticProps<DAODataType & { og: OgObject }> = async (context) => {
+  console.log("context.params", context.params)
+  const daoData = DAODataList[Number(context.params?.id)]
+  const res = await openGraphScraper({ url: daoData.storeUrl });
+  if (res.error) console.log("openGraphScraper error", res.error);
+  return {
+    props: {
+      ...daoData,
+      og: res.result,
+    }
+  }
+};
+
+export const getStaticPaths: GetStaticPaths = () => {
+  const paths = DAODataList.map((_, index) => `/dao/${index}`);
+  return {
+    paths,
+    fallback: true,
+  };
 }


### PR DESCRIPTION
### What I did
Set title and description in DAO detail page by fetching OGP info from each link, as shown in the image below:

![localhost_3000_dao_9](https://github.com/0xShin0221/Frontend_ShopDAOGenerator_Chainlink2023/assets/111993418/08c3720e-592e-4e8d-8ec6-7e596fc7ed4e)

You can check it out [here](https://frontend-shop-dao-generator-chainlink2023-git-f-101559-de-store.vercel.app/dao/9)
